### PR TITLE
第二章中的金融报告代码有个小错误，结构FinancialReport上面并没有写#[derive(Debug)]特征。也不需要引入fmt。

### DIFF
--- a/PART I 基础部分 - 量化语境下的Rust编程基础.md
+++ b/PART I 基础部分 - 量化语境下的Rust编程基础.md
@@ -564,11 +564,9 @@ fn main() {
 **金融报告**：(由**Debug Trait**推导)
 
 ```rust
-// 导入 fmt 模块中的 fmt trait，用于实现自定义格式化
-use std::fmt;
-
 // 定义一个结构体 FinancialReport，表示财务报告
 // 使用 #[derive(Debug)] 属性来自动实现 Debug trait，以便能够使用 {:?} 打印调试信息
+#[derive(Debug)]
 struct FinancialReport {
     income: f64,    // 收入
     expenses: f64,  // 支出

--- a/docs/PART I 基础部分/Chapter 02 - 格式化输出.md
+++ b/docs/PART I 基础部分/Chapter 02 - 格式化输出.md
@@ -166,11 +166,9 @@ fn main() {
 **金融报告：（由 Debug Trait 推导）**
 
 ```rust
-// 导入 fmt 模块中的 fmt trait，用于实现自定义格式化
-use std::fmt;
-
 // 定义一个结构体 FinancialReport，表示财务报告
 // 使用 #[derive(Debug)] 属性来自动实现 Debug trait，以便能够使用 {:?} 打印调试信息
+#[derive(Debug)]
 struct FinancialReport {
     income: f64,    // 收入
     expenses: f64,  // 支出


### PR DESCRIPTION
第二章中的金融报告代码有个小错误，结构FinancialReport上面并没有写#[derive(Debug)]特征。使用#[derive(Debug)]特征也不需要引入fmt。